### PR TITLE
Using `.First` instead of `.Single`

### DIFF
--- a/src/MudBlazor.Markdown/MudMarkdown.razor.cs
+++ b/src/MudBlazor.Markdown/MudMarkdown.razor.cs
@@ -153,7 +153,7 @@ namespace MudBlazor
 							}
 						case LinkInline x:
 							{
-								var content = (LiteralInline)x.Single();
+								var content = (LiteralInline)x.First();
 
 								if (LinkCommand == null)
 								{


### PR DESCRIPTION
`.Single()` returns the only element of a sequence, and throws an exception if there is not exactly one element in the sequence. It is better to use `.First()` instead which only returns the first element in the sequence and does not throw an exception.