### PR TITLE
remove package.json files from NuGet content

### DIFF
--- a/MudBlazor.Markdown.sln
+++ b/MudBlazor.Markdown.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.31229.75
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Markdown", "src\MudBlazor.Markdown\MudBlazor.Markdown.csproj", "{D98CF970-15A6-4174-9180-FD5BACA76BDD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MudBlazor.Markdown.Tests", "tests\MudBlazor.Markdown.Tests\MudBlazor.Markdown.Tests.csproj", "{CEE74ADB-80A4-4011-A2C6-68EB7902409A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MudBlazor.Markdown.Tests", "tests\MudBlazor.Markdown.Tests\MudBlazor.Markdown.Tests.csproj", "{CEE74ADB-80A4-4011-A2C6-68EB7902409A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/MudBlazor.Markdown/MudBlazor.Markdown.csproj
+++ b/src/MudBlazor.Markdown/MudBlazor.Markdown.csproj
@@ -27,12 +27,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <None Include="..\..\favico.png" Pack="true" PackagePath=""/>
+		<None Include="..\..\favico.png" Pack="true" PackagePath=""/>
 		<Content Remove="**\package*.json" />
 	</ItemGroup>
 
 	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-	  <Exec Command="gulp" />
+		<Exec Command="gulp" />
 	</Target>
 
 </Project>

--- a/src/MudBlazor.Markdown/MudBlazor.Markdown.csproj
+++ b/src/MudBlazor.Markdown/MudBlazor.Markdown.csproj
@@ -27,10 +27,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <None Include="..\..\favico.png">
-	    <Pack>True</Pack>
-	    <PackagePath></PackagePath>
-	  </None>
+	  <None Include="..\..\favico.png" Pack="true" PackagePath=""/>
+		<Content Remove="**\package*.json" />
 	</ItemGroup>
 
 	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">


### PR DESCRIPTION
Issue #11

Previously `package.json` and `package-lock.json` were in the *content* folder of the NuGet package. There is no need to do it
![image](https://user-images.githubusercontent.com/47413092/128703303-e3303767-dc16-49bc-affb-375e8ea984a3.png)

After the fix the content folder is not packed any more
![image](https://user-images.githubusercontent.com/47413092/128703458-5e2bf1b7-0c74-434b-a091-80df56c0ac39.png)