### PR TITLE
Run npm script instead of global script

### DIFF
--- a/src/MudBlazor.Markdown/MudBlazor.Markdown.csproj
+++ b/src/MudBlazor.Markdown/MudBlazor.Markdown.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-		<Exec Command="gulp" />
+		<Exec Command="npm run build" />
 	</Target>
 
 </Project>

--- a/src/MudBlazor.Markdown/package.json
+++ b/src/MudBlazor.Markdown/package.json
@@ -7,6 +7,9 @@
 		"markdown",
 		"blazor"
 	],
+	"scripts": {
+		"build": "gulp"
+	},
 	"author": "MyNihongo",
 	"license": "MIT",
 	"devDependencies": {


### PR DESCRIPTION
Runs an npm build script instead of a global script in the pre-build step. This is prefered so you don't have to install gulp globally.