### PR TITLE
Add configurable Typography Variant depending on Heading Level

### DIFF
--- a/src/MudBlazor.Markdown/MudMarkdown.razor.cs
+++ b/src/MudBlazor.Markdown/MudMarkdown.razor.cs
@@ -35,6 +35,42 @@ namespace MudBlazor
 		[Parameter]
 		public ICommand? LinkCommand { get; set; }
 
+		/// <summary>
+		/// Typography variant to use for Heading Level 1.<br/>
+		/// Default: <see cref="Typo.h1"/>
+		/// </summary>
+		[Parameter] public Typo H1Typo { get; set; } = Typo.h1;
+
+		/// <summary>
+		/// Typography variant to use for Heading Level 2.<br/>
+		/// Default: <see cref="Typo.h2"/>
+		/// </summary>
+		[Parameter] public Typo H2Typo { get; set; } = Typo.h2;
+
+		/// <summary>
+		/// Typography variant to use for Heading Level 3.<br/>
+		/// Default: <see cref="Typo.h3"/>
+		/// </summary>
+		[Parameter] public Typo H3Typo { get; set; } = Typo.h3;
+
+		/// <summary>
+		/// Typography variant to use for Heading Level 4.<br/>
+		/// Default: <see cref="Typo.h4"/>
+		/// </summary>
+		[Parameter] public Typo H4Typo { get; set; } = Typo.h4;
+
+		/// <summary>
+		/// Typography variant to use for Heading Level 5.<br/>
+		/// Default: <see cref="Typo.h5"/>
+		/// </summary>
+		[Parameter] public Typo H5Typo { get; set; } = Typo.h5;
+
+		/// <summary>
+		/// Typography variant to use for Heading Level 6.<br/>
+		/// Default: <see cref="Typo.h6"/>
+		/// </summary>
+		[Parameter] public Typo H6Typo { get; set; } = Typo.h6;
+
 		protected override void BuildRenderTree(RenderTreeBuilder builder)
 		{
 			if (string.IsNullOrEmpty(Value))
@@ -67,12 +103,12 @@ namespace MudBlazor
 						{
 							Typo? typo = heading.Level switch
 							{
-								1 => Typo.h1,
-								2 => Typo.h2,
-								3 => Typo.h3,
-								4 => Typo.h4,
-								5 => Typo.h5,
-								6 => Typo.h6,
+								1 => H1Typo,
+								2 => H2Typo,
+								3 => H3Typo,
+								4 => H4Typo,
+								5 => H5Typo,
+								6 => H6Typo,
 								_ => null
 							};
 

--- a/tests/MudBlazor.Markdown.Tests/ComponentParameterCollectionBuilderEx.cs
+++ b/tests/MudBlazor.Markdown.Tests/ComponentParameterCollectionBuilderEx.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Linq.Expressions;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.Markdown.Tests
+{
+    public static class ComponentParameterCollectionBuilderEx
+    {
+        public static ComponentParameterCollectionBuilder<TComponent> AddIfNotNull<TComponent, TValue>(
+            this ComponentParameterCollectionBuilder<TComponent> @this,
+            Expression<Func<TComponent, TValue>> parameterSelector,
+            TValue value)
+            where TComponent : IComponent
+        {
+            return value != null
+                ? @this.Add(parameterSelector, value)
+                : @this;
+        }
+    }
+}

--- a/tests/MudBlazor.Markdown.Tests/MudMarkdownTests.cs
+++ b/tests/MudBlazor.Markdown.Tests/MudMarkdownTests.cs
@@ -326,14 +326,14 @@ $@"<article class='mud-markdown-body'>
 		}
 
 		[Theory]
-		[InlineData("#", Typo.h2, "h2")]
-		[InlineData("#", Typo.h3, "h3")]
-		[InlineData("#", Typo.h4, "h4")]
-		[InlineData("#", Typo.h5, "h5")]
-		[InlineData("#", Typo.h6, "h6")]
-		public void RenderHeadersWithDifferentTypo(string valueInput, Typo newTypo, string expected)
+		[InlineData(Typo.h2, "h2")]
+		[InlineData(Typo.h3, "h3")]
+		[InlineData(Typo.h4, "h4")]
+		[InlineData(Typo.h5, "h5")]
+		[InlineData(Typo.h6, "h6")]
+		public void RenderHeadersWithDifferentTypo(Typo newTypo, string expected)
 		{
-			var value = valueInput + " some text";
+			const string value = "# some text";
 			var expectedValue = string.Format("<article class='mud-markdown-body'><{0} class='mud-typography mud-typography-{0} mud-inherit-text'>some text</{0}></article>", expected);
 
 			using var fixture = CreateFixture(value, h1Typo: newTypo);

--- a/tests/MudBlazor.Markdown.Tests/MudMarkdownTests.cs
+++ b/tests/MudBlazor.Markdown.Tests/MudMarkdownTests.cs
@@ -325,6 +325,21 @@ $@"<article class='mud-markdown-body'>
 			fixture.MarkupMatches(expectedValue);
 		}
 
+		[Theory]
+		[InlineData("#", Typo.h2, "h2")]
+		[InlineData("#", Typo.h3, "h3")]
+		[InlineData("#", Typo.h4, "h4")]
+		[InlineData("#", Typo.h5, "h5")]
+		[InlineData("#", Typo.h6, "h6")]
+		public void RenderHeadersWithDifferentTypo(string valueInput, Typo newTypo, string expected)
+		{
+			var value = valueInput + " some text";
+			var expectedValue = string.Format("<article class='mud-markdown-body'><{0} class='mud-typography mud-typography-{0} mud-inherit-text'>some text</{0}></article>", expected);
+
+			using var fixture = CreateFixture(value, h1Typo: newTypo);
+			fixture.MarkupMatches(expectedValue);
+		}
+		
 		[Fact]
 		public void RenderLineSeparator()
 		{

--- a/tests/MudBlazor.Markdown.Tests/MudMarkdownTestsBase.cs
+++ b/tests/MudBlazor.Markdown.Tests/MudMarkdownTestsBase.cs
@@ -9,18 +9,17 @@ namespace MudBlazor.Markdown.Tests
 		private readonly TestContext _ctx = new();
 
 		protected IRenderedComponent<MudMarkdown> CreateFixture(string value, ICommand command = null, int? tableCellMinWidth = null,
-			Typo h1Typo = Typo.h1, Typo h2Typo = Typo.h2, Typo h3Typo = Typo.h3, Typo h4Typo = Typo.h4, Typo h5Typo = Typo.h5,
-			Typo h6Typo = Typo.h6) =>
+			Typo h1Typo = Typo.h1, Typo h2Typo = Typo.h2, Typo h3Typo = Typo.h3, Typo h4Typo = Typo.h4, Typo h5Typo = Typo.h5, Typo h6Typo = Typo.h6) =>
 			_ctx.RenderComponent<MudMarkdown>(@params =>
 				@params.Add(static x => x.Value, value)
 					.Add(static x => x.LinkCommand, command)
 					.Add(static x => x.TableCellMinWidth, tableCellMinWidth)
-					.Add(static x => x.H1Typo, h1Typo)
-					.Add(static x => x.H2Typo, h2Typo)
-					.Add(static x => x.H3Typo, h3Typo)
-					.Add(static x => x.H4Typo, h4Typo)
-					.Add(static x => x.H5Typo, h5Typo)
-					.Add(static x => x.H6Typo, h6Typo));
+					.AddIfNotNull(static x => x.H1Typo, h1Typo)
+					.AddIfNotNull(static x => x.H2Typo, h2Typo)
+					.AddIfNotNull(static x => x.H3Typo, h3Typo)
+					.AddIfNotNull(static x => x.H4Typo, h4Typo)
+					.AddIfNotNull(static x => x.H5Typo, h5Typo)
+					.AddIfNotNull(static x => x.H6Typo, h6Typo));
 
 		public void Dispose()
 		{

--- a/tests/MudBlazor.Markdown.Tests/MudMarkdownTestsBase.cs
+++ b/tests/MudBlazor.Markdown.Tests/MudMarkdownTestsBase.cs
@@ -8,11 +8,19 @@ namespace MudBlazor.Markdown.Tests
 	{
 		private readonly TestContext _ctx = new();
 
-		protected IRenderedComponent<MudMarkdown> CreateFixture(string value, ICommand command = null, int? tableCellMinWidth = null) =>
+		protected IRenderedComponent<MudMarkdown> CreateFixture(string value, ICommand command = null, int? tableCellMinWidth = null,
+			Typo h1Typo = Typo.h1, Typo h2Typo = Typo.h2, Typo h3Typo = Typo.h3, Typo h4Typo = Typo.h4, Typo h5Typo = Typo.h5,
+			Typo h6Typo = Typo.h6) =>
 			_ctx.RenderComponent<MudMarkdown>(@params =>
 				@params.Add(static x => x.Value, value)
 					.Add(static x => x.LinkCommand, command)
-					.Add(static x => x.TableCellMinWidth, tableCellMinWidth));
+					.Add(static x => x.TableCellMinWidth, tableCellMinWidth)
+					.Add(static x => x.H1Typo, h1Typo)
+					.Add(static x => x.H2Typo, h2Typo)
+					.Add(static x => x.H3Typo, h3Typo)
+					.Add(static x => x.H4Typo, h4Typo)
+					.Add(static x => x.H5Typo, h5Typo)
+					.Add(static x => x.H6Typo, h6Typo));
 
 		public void Dispose()
 		{


### PR DESCRIPTION
This adds configurable Typography Variants so you can eg use `Typo.h3` for Heading Level 1. Since having a ton of Parameters on a Component is not really performance friendly I would suggest looking into some sort of `MarkdownConfiguration` Parameter where you can fully configure the Component so you don't end up with 100 Parameters.