### PR TITLE
Fix highlight.js highlighting with language specified code blocks

### DIFF
--- a/src/MudBlazor.Markdown/Components/MudCodeHighlight.razor.cs
+++ b/src/MudBlazor.Markdown/Components/MudCodeHighlight.razor.cs
@@ -61,7 +61,7 @@ public class MudCodeHighlight : MudComponentBase, IDisposable
 
 		builder.OpenElement(i++, "pre");
 		builder.OpenElement(i++, "code");
-
+		builder.AddAttribute(i++, "class", $"language-{Language}");
 		builder.AddElementReferenceCapture(i++, x => _ref = x);
 		builder.AddContent(i++, Text);
 
@@ -84,7 +84,7 @@ public class MudCodeHighlight : MudComponentBase, IDisposable
 		if (!firstRender || Js == null)
 			return;
 
-		await Js.InvokeVoidAsync("highlightCodeElement", _ref, Language)
+		await Js.InvokeVoidAsync("highlightCodeElement", _ref)
 			.ConfigureAwait(false);
 
 		if (!_isFirstThemeSet)

--- a/src/MudBlazor.Markdown/Components/MudCodeHighlight.razor.cs
+++ b/src/MudBlazor.Markdown/Components/MudCodeHighlight.razor.cs
@@ -62,10 +62,10 @@ public class MudCodeHighlight : MudComponentBase, IDisposable
 		builder.OpenElement(i++, "pre");
 		builder.OpenElement(i++, "code");
 
-        if (!string.IsNullOrEmpty(Language))
-            builder.AddAttribute(i++, "class", $"language-{Language}");
+		if (!string.IsNullOrEmpty(Language))
+			builder.AddAttribute(i++, "class", $"language-{Language}");
 
-        builder.AddElementReferenceCapture(i++, x => _ref = x);
+		builder.AddElementReferenceCapture(i++, x => _ref = x);
 		builder.AddContent(i++, Text);
 
 		builder.CloseElement();

--- a/src/MudBlazor.Markdown/Components/MudCodeHighlight.razor.cs
+++ b/src/MudBlazor.Markdown/Components/MudCodeHighlight.razor.cs
@@ -61,8 +61,11 @@ public class MudCodeHighlight : MudComponentBase, IDisposable
 
 		builder.OpenElement(i++, "pre");
 		builder.OpenElement(i++, "code");
-		builder.AddAttribute(i++, "class", $"language-{Language}");
-		builder.AddElementReferenceCapture(i++, x => _ref = x);
+
+        if (!string.IsNullOrEmpty(Language))
+            builder.AddAttribute(i++, "class", $"language-{Language}");
+
+        builder.AddElementReferenceCapture(i++, x => _ref = x);
 		builder.AddContent(i++, Text);
 
 		builder.CloseElement();

--- a/src/MudBlazor.Markdown/Resources/MudBlazor.Markdown.js
+++ b/src/MudBlazor.Markdown/Resources/MudBlazor.Markdown.js
@@ -3,8 +3,8 @@
 const codeStylesDir = "code-styles";
 const codeStylesSegment = `/MudBlazor.Markdown/${codeStylesDir}/`;
 
-window.highlightCodeElement = function (element, lang) {
-	hljs.highlightElement(element, { language: lang });
+window.highlightCodeElement = function (element) {
+	hljs.highlightElement(element);
 }
 
 window.setHighlightStylesheet = function (stylesheetPath) {

--- a/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentCasesShould.cs
+++ b/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentCasesShould.cs
@@ -275,14 +275,13 @@ code
 
 	#endregion
 
-
 	#region https://github.com/MyNihongo/MudBlazor.Markdown/issues/102
 
 	[Fact]
 	public void RenderCodeBlockWithoutLanguage()
 	{
 		const string value =
-			@"```
+@"```
 public bool IsMudBlazorCool()
 {
 	return true;
@@ -290,7 +289,7 @@ public bool IsMudBlazorCool()
 ```";
 
 		const string expected =
-			@"<article class='mud-markdown-body'>
+@"<article class='mud-markdown-body'>
 	<pre><code blazor:elementReference='9d940986-b033-4d4d-97f0-2c11f46dda30'>public bool IsMudBlazorCool()
 {
     return true;

--- a/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentCasesShould.cs
+++ b/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentCasesShould.cs
@@ -290,9 +290,10 @@ public bool IsMudBlazorCool()
 
 		const string expected =
 @"<article class='mud-markdown-body'>
-	<pre>
-		<code blazor:elementReference='9d940986-b033-4d4d-97f0-2c11f46dda30'>public bool IsMudBlazorCool()&#xD;&#xA;{&#xD;&#xA;&#x9;return true;&#xD;&#xA;}</code>
-	</pre>
+	<pre><code blazor:elementReference='9d940986-b033-4d4d-97f0-2c11f46dda30'>public bool IsMudBlazorCool()
+{
+    return true;
+}</code></pre>
 </article>";
 
 		using var fixture = CreateFixture(value);

--- a/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentCasesShould.cs
+++ b/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentCasesShould.cs
@@ -290,10 +290,9 @@ public bool IsMudBlazorCool()
 
 		const string expected =
 @"<article class='mud-markdown-body'>
-	<pre><code blazor:elementReference='9d940986-b033-4d4d-97f0-2c11f46dda30'>public bool IsMudBlazorCool()
-{
-    return true;
-}</code></pre>
+	<pre>
+		<code blazor:elementReference='9d940986-b033-4d4d-97f0-2c11f46dda30'>public bool IsMudBlazorCool()&#xD;&#xA;{&#xD;&#xA;&#x9;return true;&#xD;&#xA;}</code>
+	</pre>
 </article>";
 
 		using var fixture = CreateFixture(value);

--- a/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentCasesShould.cs
+++ b/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentCasesShould.cs
@@ -234,7 +234,7 @@ public int GetTheAnswer()
 @"<article class='mud-markdown-body'>
 	<h1 id='heading-1' class='mud-typography mud-typography-h1'>Heading 1</h1>
 	<p class='mud-typography mud-typography-body1'>Some text.</p>
-	<pre><code blazor:elementReference='8035dc45-0e97-419e-869c-51a5d65602d4'>public int GetTheAnswer()&#xD;&#xA;{&#xD;&#xA;   return 42;&#xD;&#xA;}</code></pre>
+	<pre><code blazor:elementReference='8035dc45-0e97-419e-869c-51a5d65602d4' class='language-csharp'>public int GetTheAnswer()&#xD;&#xA;{&#xD;&#xA;   return 42;&#xD;&#xA;}</code></pre>
 	<h2 id='another-headline-1' class='mud-typography mud-typography-h2'>Another headline 1</h2>
 	<h2 id='another-headline-2' class='mud-typography mud-typography-h2'>Another headline 2</h2>
 </article>";
@@ -260,13 +260,41 @@ code
 
 		const string expected = 
 @"<article class='mud-markdown-body'>
-	<pre><code blazor:elementReference='9d940986-b033-4d4d-97f0-2c11f46dda30'>some&#xD;&#xA;code</code></pre>
+	<pre><code blazor:elementReference='9d940986-b033-4d4d-97f0-2c11f46dda30' class='language-text'>some&#xD;&#xA;code</code></pre>
 	<ul>
 		<li><p class='mud-typography mud-typography-body1'>List item 1</p></li>
 		<li><p class='mud-typography mud-typography-body1'>List item 2</p></li>
 		<li><p class='mud-typography mud-typography-body1'>List item 3</p></li>
 	</ul>
 	<h2 id='another-headline' class='mud-typography mud-typography-h2'>Another headline</h2>
+</article>";
+
+		using var fixture = CreateFixture(value);
+		fixture.MarkupMatches(expected);
+	}
+
+	#endregion
+
+
+	#region https://github.com/MyNihongo/MudBlazor.Markdown/issues/102
+
+	[Fact]
+	public void RenderCodeBlockWithoutLanguage()
+	{
+		const string value =
+			@"```
+public bool IsMudBlazorCool()
+{
+	return true;
+}
+```";
+
+		const string expected =
+			@"<article class='mud-markdown-body'>
+	<pre><code blazor:elementReference='9d940986-b033-4d4d-97f0-2c11f46dda30'>public bool IsMudBlazorCool()
+{
+    return true;
+}</code></pre>
 </article>";
 
 		using var fixture = CreateFixture(value);

--- a/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentShould.cs
+++ b/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentShould.cs
@@ -466,7 +466,7 @@ public bool IsMudBlazorCool()
 ```";
 
 		const string expected =
-@"<article class='mud-markdown-body'><pre><code blazor:elementReference='3b498767-f59e-4a18-a27d-a828bf3dd0e5'>public bool IsMudBlazorCool()&#xD;&#xA;{&#xD;&#xA;&#x9;return true;&#xD;&#xA;}</code></pre></article>";
+@"<article class='mud-markdown-body'><pre><code blazor:elementReference='3b498767-f59e-4a18-a27d-a828bf3dd0e5' class='language-cs'>public bool IsMudBlazorCool()&#xD;&#xA;{&#xD;&#xA;&#x9;return true;&#xD;&#xA;}</code></pre></article>";
 
 		using var fixture = CreateFixture(value);
 		fixture.MarkupMatches(expected);


### PR DESCRIPTION
Fixes #102 

Before this commit the following would both render identically with go formatting as it was using highlight.js autodetection:

<pre>
```go
func main() {
    fmt.Println("Hello, 世界")
}
```
```plaintext
func main() {
    fmt.Println("Hello, 世界")
}
```
</pre>

After this commit the latter will correctly render as plaintext.