### PR TITLE
added property 'style' to the image tag

### DIFF
--- a/src/MudBlazor.Markdown/MudMarkdown.razor.cs
+++ b/src/MudBlazor.Markdown/MudMarkdown.razor.cs
@@ -269,6 +269,7 @@ public class MudMarkdown : ComponentBase, IDisposable
 							builder.OpenElement(_elementIndex++, "img");
 							builder.AddAttribute(_elementIndex++, "src", url);
 							builder.AddAttribute(_elementIndex++, "alt", string.Join(null, alt));
+							builder.AddAttribute(_elementIndex++, "style", "max-width: 100%;");
 							builder.CloseElement();
 						}
 						else if (LinkCommand == null)


### PR DESCRIPTION
This should fix images getting out of the mudPaper's boundaries and it's how github does it

### examples: 

**before:**
- on desktop
![before1](https://github.com/MyNihongo/MudBlazor.Markdown/assets/55938130/caf61e2d-bb6d-42cc-9c2c-91e7b2a7353f)
- on mobile
![before2](https://github.com/MyNihongo/MudBlazor.Markdown/assets/55938130/430edee7-e6cc-4c8b-b065-b64ed623f7b5)

**After:**
- on desktop
![after1](https://github.com/MyNihongo/MudBlazor.Markdown/assets/55938130/44e8c8f9-d17f-47c9-a5b8-3ee5ff878398)
- on mobile
![after2](https://github.com/MyNihongo/MudBlazor.Markdown/assets/55938130/def8fc3d-4229-4817-9f32-7e1301a7762c)

