### PR TITLE
🐛 Margin-Bottom for Quote wrong (#194)

### DIFF
--- a/src/MudBlazor.Markdown/Resources/MudBlazor.Markdown.css
+++ b/src/MudBlazor.Markdown/Resources/MudBlazor.Markdown.css
@@ -34,7 +34,10 @@ pre code.hljs {
 	color: var(--mud-palette-text-secondary);
 	background-color: var(--mud-palette-drawer-background);
 	padding: 0.25em 1em;
-	margin: 0.5em 0;
+	margin: 0.5em 0 1.25em;
+}
+.mud-markdown-body blockquote p {
+	margin-bottom: 0 !important;
 }
 
 /* Table */

--- a/src/MudBlazor.Markdown/Resources/MudBlazor.Markdown.css
+++ b/src/MudBlazor.Markdown/Resources/MudBlazor.Markdown.css
@@ -36,9 +36,10 @@ pre code.hljs {
 	padding: 0.25em 1em;
 	margin: 0.5em 0 1.25em;
 }
-.mud-markdown-body blockquote p {
-	margin-bottom: 0 !important;
-}
+
+	.mud-markdown-body blockquote p {
+		margin-bottom: 0 !important;
+	}
 
 /* Table */
 .mud-markdown-body table {


### PR DESCRIPTION
Fixed CSS for quote and p

![image](https://github.com/MyNihongo/MudBlazor.Markdown/assets/61717342/37a2be71-dd2d-4eaf-a3a8-996161f8d5eb)
