### PR TITLE
Allow parsing of fenced code blocks inside lists

### DIFF
--- a/src/MudBlazor.Markdown/MudMarkdown.razor.cs
+++ b/src/MudBlazor.Markdown/MudMarkdown.razor.cs
@@ -432,7 +432,20 @@ public class MudMarkdown : ComponentBase, IDisposable
 						builder.CloseElement();
 						break;
 					}
-					default:
+                    case FencedCodeBlock code:
+                    {
+                        builder.OpenElement(ElementIndex++, "li");
+                        var text = code.CreateCodeBlockText();
+
+                        builder.OpenComponent<MudCodeHighlight>(ElementIndex++);
+                        builder.AddAttribute(ElementIndex++, nameof(MudCodeHighlight.Text), text);
+                        builder.AddAttribute(ElementIndex++, nameof(MudCodeHighlight.Language), code.Info ?? string.Empty);
+                        builder.AddAttribute(ElementIndex++, nameof(MudCodeHighlight.Theme), CodeBlockTheme);
+                        builder.CloseComponent();
+                        builder.CloseElement();
+                        break;
+                    }
+                    default:
 					{
 						OnRenderListDefault(block[j], builder);
 						break;

--- a/src/MudBlazor.Markdown/MudMarkdown.razor.cs
+++ b/src/MudBlazor.Markdown/MudMarkdown.razor.cs
@@ -432,20 +432,20 @@ public class MudMarkdown : ComponentBase, IDisposable
 						builder.CloseElement();
 						break;
 					}
-                    case FencedCodeBlock code:
-                    {
-                        builder.OpenElement(ElementIndex++, "li");
-                        var text = code.CreateCodeBlockText();
+					case FencedCodeBlock code:
+					{
+						builder.OpenElement(ElementIndex++, "li");
+						var text = code.CreateCodeBlockText();
 
-                        builder.OpenComponent<MudCodeHighlight>(ElementIndex++);
-                        builder.AddAttribute(ElementIndex++, nameof(MudCodeHighlight.Text), text);
-                        builder.AddAttribute(ElementIndex++, nameof(MudCodeHighlight.Language), code.Info ?? string.Empty);
-                        builder.AddAttribute(ElementIndex++, nameof(MudCodeHighlight.Theme), CodeBlockTheme);
-                        builder.CloseComponent();
-                        builder.CloseElement();
-                        break;
-                    }
-                    default:
+						builder.OpenComponent<MudCodeHighlight>(ElementIndex++);
+						builder.AddAttribute(ElementIndex++, nameof(MudCodeHighlight.Text), text);
+						builder.AddAttribute(ElementIndex++, nameof(MudCodeHighlight.Language), code.Info ?? string.Empty);
+						builder.AddAttribute(ElementIndex++, nameof(MudCodeHighlight.Theme), CodeBlockTheme);
+						builder.CloseComponent();
+						builder.CloseElement();
+						break;
+					}
+					default:
 					{
 						OnRenderListDefault(block[j], builder);
 						break;


### PR DESCRIPTION
While working with the Mudblazor.Markdown package, I discovered that, if a block of Markdown text being parsed included a fenced code block within a list, the code block would not be rendered in the output.  This pull request is designed to correct this issue.

The following Markdown can be used as an example:

> To prevent the warning message regarding the deprecation of the `mysql_native_password` plugin from being logged, you have a couple of options:
> 
> Option 1: Update User Authentication Method:
> 
> 1. Connect to your MySQL server using a MySQL client, such as the `mysql` command-line tool:
>    ```bash
>    mysql -u username -p
>    ```
> 
> 2. Once connected, run the following command to alter the user's authentication method:
>    ```sql
>    ALTER USER 'username'@'hostname' IDENTIFIED WITH caching_sha2_password;
>    ```
>    Replace `'username'` with the actual username and `'hostname'` with the appropriate hostname or IP address. If you want to update for all users, replace `'username'@'hostname'` with `'*'@'%'`.
> 
> 3. Repeat this process for each user on your MySQL server.