### PR TITLE
Add strikethrough support

### DIFF
--- a/samples/MudBlazor.Markdown.Core/sample.md
+++ b/samples/MudBlazor.Markdown.Core/sample.md
@@ -5,7 +5,7 @@
 ##### Heading 5
 ###### Heading 6
 
-Some regular text. *Text in italics*, **text in bold.** and ~~text in strikethrough~~.
+Some regular text. *Text in italics*, **text in bold** and ~~text in strikethrough~~.
 **Bold and *italics within***.
 *Italics and **bold within***.
 It is possible to `highlight some code`.

--- a/samples/MudBlazor.Markdown.Core/sample.md
+++ b/samples/MudBlazor.Markdown.Core/sample.md
@@ -5,7 +5,7 @@
 ##### Heading 5
 ###### Heading 6
 
-Some regular text. *Text in italics* and **text in bold**.
+Some regular text. *Text in italics*, **text in bold.** and ~~text in strikethrough~~.
 **Bold and *italics within***.
 *Italics and **bold within***.
 It is possible to `highlight some code`.

--- a/src/MudBlazor.Markdown/Extensions/EmphasisInlineEx.cs
+++ b/src/MudBlazor.Markdown/Extensions/EmphasisInlineEx.cs
@@ -6,7 +6,10 @@ internal static class EmphasisInlineEx
 {
 	public static bool TryGetEmphasisElement(this EmphasisInline emphasis, out string value)
 	{
-		const string italics = "i", bold = "b";
+		const string
+			italics = "i",
+			bold = "b",
+			strike = "del";
 
 		value = emphasis.DelimiterChar switch
 		{
@@ -17,6 +20,11 @@ internal static class EmphasisInlineEx
 				_ => string.Empty
 			},
 			'_' => italics,
+			'~' => emphasis.DelimiterCount switch
+			{
+				2 => strike,
+				_ => string.Empty
+			},
 			_ => string.Empty
 		};
 

--- a/src/MudBlazor.Markdown/Extensions/EmphasisInlineEx.cs
+++ b/src/MudBlazor.Markdown/Extensions/EmphasisInlineEx.cs
@@ -6,10 +6,7 @@ internal static class EmphasisInlineEx
 {
 	public static bool TryGetEmphasisElement(this EmphasisInline emphasis, out string value)
 	{
-		const string
-			italics = "i",
-			bold = "b",
-			strike = "del";
+		const string italics = "i", bold = "b", strikethrough = "del";
 
 		value = emphasis.DelimiterChar switch
 		{
@@ -22,7 +19,7 @@ internal static class EmphasisInlineEx
 			'_' => italics,
 			'~' => emphasis.DelimiterCount switch
 			{
-				2 => strike,
+				2 => strikethrough,
 				_ => string.Empty
 			},
 			_ => string.Empty

--- a/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentShould.cs
+++ b/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentShould.cs
@@ -16,14 +16,14 @@ public sealed class MarkdownComponentShould : MarkdownComponentTestsBase
 	}
 
 	[Fact]
-	public void RenderCodeItalicAndBold()
+	public void RenderCodeItalicBoldAndStrike()
 	{
-		const string value = "Some text `code` again text - *italics* text and **bold** text.";
+		const string value = "Some text `code` again text - *italics* text and also **bold** and ~~strikethrough~~ text.";
 		const string expected =
 """
 <article class='mud-markdown-body'>
 	<p class='mud-typography mud-typography-body1'>
-		Some text <code>code</code> again text - <i>italics</i> text and <b>bold</b> text.
+		Some text <code>code</code> again text - <i>italics</i> text and also <b>bold</b> and <del>strikethrough</del> text.
 	</p>
 </article>
 """;
@@ -35,13 +35,13 @@ public sealed class MarkdownComponentShould : MarkdownComponentTestsBase
 	[Fact]
 	public void RenderBlockQuotes()
 	{
-		const string value = ">Some text `code` again text - *italics* text and **bold** text.";
+		const string value = ">Some text `code` again text - *italics* text and also **bold** and ~~strikethrough~~ text.";
 		const string expected =
 """
 <article class='mud-markdown-body'>
 	<blockquote>
 		<p class='mud-typography mud-typography-body1'>
-			Some text <code>code</code> again text - <i>italics</i> text and <b>bold</b> text.
+			Some text <code>code</code> again text - <i>italics</i> text and also <b>bold</b> and <del>strikethrough</del> text.
 		</p>
 	</blockquote>
 </article>

--- a/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentShould.cs
+++ b/tests/MudBlazor.Markdown.Tests/MarkdownComponentTests/MarkdownComponentShould.cs
@@ -16,7 +16,7 @@ public sealed class MarkdownComponentShould : MarkdownComponentTestsBase
 	}
 
 	[Fact]
-	public void RenderCodeItalicBoldAndStrike()
+	public void RenderEmphasisElements()
 	{
 		const string value = "Some text `code` again text - *italics* text and also **bold** and ~~strikethrough~~ text.";
 		const string expected =


### PR DESCRIPTION
|Before|After|
|-------|------|
|![before](https://github.com/user-attachments/assets/f3c6de3f-9a3e-42a2-a97b-979a4ee81ec4)|![after](https://github.com/user-attachments/assets/aa33075d-eaf3-401b-8ee8-3cc086850dfc)|

This is a simple change, but the code might need more refactoring as currently if any invalid emphasis is detected, the entire text rendering is skipped. I'd like to have it so that invalid/unsupported emphasis is drawn with a red background so that it is clearer to the user when errors happen instead of just hiding the text completely. That feature was out of the scope of this PR, though I can add it in a separate PR if this idea sounds like something worth pursuing.